### PR TITLE
#2636, Add the takeover tag to the template

### DIFF
--- a/dns/servfail-refused-hosts.yaml
+++ b/dns/servfail-refused-hosts.yaml
@@ -4,7 +4,7 @@ info:
   name: Servfail Host Finder
   author: pdteam
   severity: info
-  tags: dns
+  tags: dns,takeover
 
 dns:
   - name: "{{FQDN}}"


### PR DESCRIPTION
### Template / PR Information

The template indicates a possible subdomain takeover vulnerability, therefore it should have the takeover tag.

### Template Validation

I've validated this template locally?
- [x] YES

